### PR TITLE
style paper-item in todo element

### DIFF
--- a/elements/todo-element.html
+++ b/elements/todo-element.html
@@ -63,6 +63,10 @@
     paper-input {
 		margin: 0 2vw;
 	}
+	  
+    paper-item {
+      width: 80%;
+    }
     
   </style>
   <template>


### PR DESCRIPTION
paper-item in todo-element occupies full width. This obscures the paper-fab button for clicks, though it is visible.
